### PR TITLE
Manual select

### DIFF
--- a/SpectrumExtractor/spectrum_extractor.config
+++ b/SpectrumExtractor/spectrum_extractor.config
@@ -19,6 +19,9 @@ CosmicRayCleanSigclip = 5
 VarianceExt = None
 
 [tracing_settings]
+# Automatic or manual
+Mode = MANUAL
+
 # Continuum flat source to be used for aperture extraction
 ContinuumFile = None
 

--- a/SpectrumExtractor/spectrum_extractor.py
+++ b/SpectrumExtractor/spectrum_extractor.py
@@ -535,6 +535,7 @@ def CalculateShiftInXD(SpectrumImage, RefImage=None, XDshiftmodel='p0',Coeffmode
     Splits_RefImage = np.split(RefImage[:,DWindowToUse[0]:DWindowToUse[0]+NoOfXDstripes*StripWidth],NoOfXDstripes,axis=1)
     Indices = list(range(len(Splits_SpectrumImage)))
     # Fit starting at the center where flux will likely be maximum, after finishing to right, return and do towards the left.
+    plt.figure()
     for i in Indices[NoOfXDstripes//2:]+Indices[NoOfXDstripes//2-1::-1]:
         XDSliceSpec = Splits_SpectrumImage[i]
         XDSliceRef = Splits_RefImage[i]
@@ -573,10 +574,10 @@ def CalculateShiftInXD(SpectrumImage, RefImage=None, XDshiftmodel='p0',Coeffmode
             logging.debug('XD offset fit {0}:{1}'.format(i,fitted_driftp))
             XDShiftCoeffDict[centerx] = fitted_driftp
             if ShowPlot:
-                plt.figure()
-                plt.plot(newRefFlux[:,0],newRefFlux[:,1]*fitted_driftp[0],color='k',alpha=0.3)
-                plt.plot(shifted_pixels,SumApFluxSpectrum,color='g',alpha=0.3)
-                plt.show(block=False)
+                # plt.figure()
+                plt.plot(newRefFlux[:,0],newRefFlux[:,1]*fitted_driftp[0],color='k',alpha=0.3, label="Reference aperture position")
+                plt.plot(shifted_pixels,SumApFluxSpectrum,color='g',alpha=0.3, label="Observed aperture position")
+                # plt.show(block=False)
 
     if int(Coeffmodel[1:]) == 0:
         Avg_XD_shift = biweight_location(np.array(list(XDShiftCoeffDict.values())),axis=0)[1:] #remove the flux scale coeff
@@ -589,6 +590,9 @@ def CalculateShiftInXD(SpectrumImage, RefImage=None, XDshiftmodel='p0',Coeffmode
             c = np.polynomial.Polynomial.fit(Dpixelpos, coeff_list, int(Coeffmodel[1:]))
             Avg_XD_shift.append(tuple(c.convert().coef))
     if ShowPlot:
+        handles, labels = plt.gca().get_legend_handles_labels()
+        by_label = dict(zip(labels, handles))
+        plt.legend(by_label.values(), by_label.keys())
         plt.title('{0}:  {1}'.format(tuple(Avg_XD_shift),tuple(DomainRange)))
         plt.xlabel('XD pixels')
         plt.ylabel('Apodized counts')

--- a/SpectrumExtractor/spectrum_extractor.py
+++ b/SpectrumExtractor/spectrum_extractor.py
@@ -444,7 +444,7 @@ def Manual_CreateApertureLabelByXDFitting(ContinuumFile,BadPixMask=None,startLoc
         norm = ImageNormalize(ContinuumFile, interval=PercentileInterval(95.),stretch=SqrtStretch())
         axs.imshow(ContinuumFile,norm=norm, origin="lower")
         axs.errorbar(point[0], point[1], yerr=point[2], fmt='o', color='red', ecolor='red')
-        axs.set_title("Select points for aperture {}\n Press 'a' on keyboard and click on required point.".format(o))
+        axs.set_title("Select points for aperture {}".format(o))
 
         def onclick(event):
             toolbar = fig.canvas.toolbar

--- a/SpectrumExtractor/spectrum_extractor.py
+++ b/SpectrumExtractor/spectrum_extractor.py
@@ -9,6 +9,7 @@ import re
 from astropy.io import fits
 from astropy.stats import mad_std, biweight_location
 from astropy.visualization import MinMaxInterval, SqrtStretch, PercentileInterval, ImageNormalize
+from astropy.modeling import models, fitting
 import matplotlib.pyplot as plt
 from skimage import filters
 from skimage import morphology
@@ -265,7 +266,6 @@ def CreateApertureLabelByXDFitting(ContinuumFile,BadPixMask=None,startLoc=None,a
 
     # Create a dictionary to save dcoordinates of each order
     FullCoorindateOfTraceDic = {o:[[d],[xd],[xde]] for o,d,xd,xde in zip(LabelList,[startLoc]*len(LabelList),XDCenterList,XDCenterList_err)}
-
     # First step to higher pixels from startLoc position and then step to lower positions
     for stepDLoc in [avgHWindow,-1*avgHWindow]:
         newDLoc = startLoc + max(1,np.abs(stepDLoc)//2)*np.sign(stepDLoc)
@@ -327,6 +327,7 @@ def CreateApertureLabelByXDFitting(ContinuumFile,BadPixMask=None,startLoc=None,a
 
     # Finally fit a trace function for each order and create an Aperture Label array
     ApertureLabel = np.zeros(ContinuumFile.shape)
+    print(FullCoorindateOfTraceDic)
     # First conver the dictionary values to a numpy array
     for o in LabelList:
         FullCoorindateOfTraceDic[o] = np.array(FullCoorindateOfTraceDic[o])
@@ -352,6 +353,179 @@ def CreateApertureLabelByXDFitting(ContinuumFile,BadPixMask=None,startLoc=None,a
     else:
         return ApertureLabel
 
+def Manual_CreateApertureLabelByXDFitting(ContinuumFile,BadPixMask=None,startLoc=None,avgHWindow=21,TraceHWidth=5,trace_fit_deg=4,
+                                          extrapolate_thresh=0.4,extrapolate_order=2,
+                                          dispersion_Xaxis=True,ShowPlot=True,return_trace=False):
+    """Creates the Aperture Trace labels by shifting and fitting profiles in Cross dispersion columns """
+    if isinstance(ContinuumFile  ,str):
+        ContinuumFile = fits.getdata(ContinuumFile)
+        if not dispersion_Xaxis:
+            ContinuumFile = ContinuumFile.T
+    if BadPixMask is not None:
+        BPMask = fits.getdata(BadPixMask) if BadPixMask[-5:] == '.fits' else np.load(BadPixMask)
+        if not dispersion_Xaxis:
+            BPMask = BPMask.T
+
+    if startLoc is None:
+        startLoc = ContinuumFile.shape[1]//2
+    # Starting labelling Reference XD cut data
+    RefXD = np.nanmedian(ContinuumFile[:,startLoc-avgHWindow:startLoc+avgHWindow],axis=1)
+    Refpixels = np.arange(len(RefXD))
+    Bkg = signal.order_filter(RefXD,domain=[True]*TraceHWidth*5,rank=int(TraceHWidth*5/10))
+    Flux = np.abs(RefXD -Bkg)
+    ThreshMask = RefXD > (Bkg + np.abs(mad_std(Flux))*6)
+    labeled_array, num_traces = ndimage.label(ThreshMask)
+    logging.info('Detected {0} order traces'.format(num_traces))
+    LabelList = []
+    XDCenterList = []
+    for label in np.sort(np.unique(labeled_array)):
+        if label == 0: # Skip 0 label
+            continue
+        M = labeled_array==label
+        centerpix = np.sum(Flux[M]*Refpixels[M])/np.sum(Flux[M])
+        LabelList.append(label)
+        XDCenterList.append(centerpix)
+    # Refine again using the TraceHWidth window
+    XDCenterList, XDCenterList_err = RefineCentriodsInSignal(Flux,XDCenterList,TraceHWidth,Xpixels=Refpixels)
+
+    if ShowPlot:
+        plt.plot(Refpixels,Flux)
+        plt.plot(Refpixels,labeled_array)
+        plt.plot(XDCenterList,LabelList,'.')
+        plt.xlabel('XD pixels')
+        plt.ylabel('Trace labels')
+        plt.show()
+
+    print('Trace_number     PixelCoord   PixelError')
+    print('\n'.join(['{0}  {1}  {2}'.format(l,p,e) for l,p,e in zip(LabelList,XDCenterList,XDCenterList_err)]))
+
+    print('Create a file with the label names and pixel coords to use.')
+    print('File format should be 3 columns :  OrderLabel PixelCoords PixelError')
+    print('Note: Trace labels should start with 1 and not zero')
+    uinputfile = input('Enter the filename :').strip()
+    if uinputfile: #User provided input
+        with open(uinputfile,'r') as labelchangefile:
+            LabelList = []
+            XDCenterList = []
+            for entry in labelchangefile:
+                if entry[0]=='#':
+                    continue
+                entry = entry.rstrip().split()
+                if len(entry)<2:
+                    continue
+                LabelList.append(int(entry[0]))
+                XDCenterList.append(float(entry[1]))
+                XDCenterList_err.append(float(entry[2]))
+        if ShowPlot:
+            print('New labelled traces')
+            plt.plot(Refpixels,Flux)
+            plt.plot(Refpixels,labeled_array)
+            plt.plot(XDCenterList,LabelList,'.')
+            plt.xlabel('XD pixels')
+            plt.ylabel('New Trace labels')
+            plt.show()
+
+    else:
+        print('No input given. No relabelling done..')
+
+    # Create a index list sorted by the pixel error as a proxy for brightness and goodness of the line to use for extrapolation
+    SortedErrorIndices = np.argsort(XDCenterList_err)
+
+    # Now start fitting the XD cut plot across the dispersion
+
+    # Create a dictionary to save dcoordinates of each order
+    FullCoorindateOfTraceDic = {o:[[d],[xd],[xde]] for o,d,xd,xde in zip(LabelList,[startLoc]*len(LabelList),XDCenterList,XDCenterList_err)}
+    # First step to higher pixels from startLoc position and then step to lower positions
+    # Add things here.
+    # Finally fit a trace function for each order and create an Aperture Label array
+    ApertureLabel = np.zeros(ContinuumFile.shape)
+    for o, point in FullCoorindateOfTraceDic.items():
+        fig, axs = plt.subplots()
+        norm = ImageNormalize(ContinuumFile, interval=PercentileInterval(95.),stretch=SqrtStretch())
+        axs.imshow(ContinuumFile,norm=norm, origin="lower")
+        axs.errorbar(point[0], point[1], yerr=point[2], fmt='o', color='red', ecolor='red')
+        axs.set_title("Select points for aperture {}\n Press 'a' on keyboard and click on required point.".format(o))
+
+        def onclick(event):
+            toolbar = fig.canvas.toolbar
+
+            if toolbar.mode != '':
+                return
+            
+            if event.inaxes != axs:
+                return
+
+            xdata, ydata = int(round(event.xdata,0)), event.ydata
+
+            width = 10
+            axs.plot([xdata, xdata], [ydata-width, ydata+width], color='black')
+            raw_profile = ContinuumFile[int(ydata)-width:int(ydata)+width, xdata]
+            x, counts, fitted_counts, g_fit = fit_gaussian_profile(raw_profile)
+            plt.figure()
+            plt.plot(raw_profile)
+            plt.plot(x, fitted_counts, label="Gaussian fit", linestyle="--")
+            plt.annotate(
+                f"fwhm : {2.355*g_fit.stddev.value:.3f} pix \n mean: {ydata-width+g_fit.mean.value:.3f}",
+                xy=(0, 1),
+                xycoords="axes fraction",
+                xytext=(10, 10),
+                textcoords='offset points',
+                color='black',
+                fontsize=9,
+                bbox=dict(boxstyle='round, pad=0.3', fc='white', alpha=0.5)
+                )
+            plt.show(block=False)
+            y_center = ydata-width+g_fit.mean.value
+            axs.plot(xdata, y_center, 'ok')
+            point[0].append(xdata)
+            point[1].append(y_center)
+            point[2].append(g_fit.stddev.value)
+        fig.canvas.mpl_connect("button_press_event", onclick)
+        FullCoorindateOfTraceDic[o] = point
+        plt.show()
+    # First conver the dictionary values to a numpy array
+    print("Manual selection of trace is completed")
+    for o in LabelList:
+        FullCoorindateOfTraceDic[o] = np.array(FullCoorindateOfTraceDic[o])
+    pix_scale_function = partial(scale_interval_m1top1,a=0,b=ContinuumFile.shape[1])
+    ApertureTraceFuncDic = Get_ApertureTraceFunction(FullCoorindateOfTraceDic,deg=trace_fit_deg,domain_scale_function=pix_scale_function)
+    # Now loop through each trace for setting the label
+    for o in reversed(sorted(LabelList)):
+        boundinside = partial(boundvalue,ll=0,ul=ApertureLabel.shape[0])
+        for j in np.arange(ApertureLabel.shape[1]):
+            mini,maxi = int(np.rint(boundinside(ApertureTraceFuncDic[o](j)-TraceHWidth))), int(np.rint(boundinside(ApertureTraceFuncDic[o](j)+TraceHWidth+1)))
+            ApertureLabel[mini:maxi,j] = o
+
+    if ShowPlot:
+        plt.imshow(np.ma.array(ApertureLabel,mask=ApertureLabel==0),cmap='hsv')
+        norm = ImageNormalize(ContinuumFile, interval=PercentileInterval(95.),stretch=SqrtStretch())
+        plt.imshow(ContinuumFile,norm=norm,alpha=0.5)
+        plt.colorbar()
+        for o in LabelList:
+            plt.plot(FullCoorindateOfTraceDic[o][0],FullCoorindateOfTraceDic[o][1],marker='.',alpha=0.5,color='k')
+        plt.show()
+    if return_trace:
+        return ApertureLabel, FullCoorindateOfTraceDic
+    else:
+        return ApertureLabel
+
+
+def fit_gaussian_profile(counts):
+    x = np.arange(len(counts))
+
+    # Initial guess: amplitude, mean, stddev
+    amplitude_guess = np.max(counts) - np.min(counts)
+    mean_guess = np.argmax(counts)
+    stddev_guess = len(counts) / 4
+
+    g_init = models.Gaussian1D(amplitude=amplitude_guess,
+                               mean=mean_guess,
+                               stddev=stddev_guess)
+    fit_g = fitting.LevMarLSQFitter()
+
+    g_fit = fit_g(g_init, x, counts)
+
+    return x, counts, g_fit(x), g_fit
 
 
 def errorfuncProfileFit(p,psf=None,xdata=None, ydata=None):
@@ -1340,12 +1514,23 @@ def main(raw_args=None):
             ApertureLabel = np.load(Config['ApertureLabel'])
         else:
             # ApertureLabel = CreateApertureLabelByThresholding(Config['ContinuumFile'],BadPixMask=Config['BadPixMask'],bsize=51,offset=0,minarea=2000, ShowPlot=True,DirectlyEnterRelabel= True)
-            ApertureLabel, ApertureCenters_Trace1 = CreateApertureLabelByXDFitting(Config['ContinuumFile'],BadPixMask=Config['BadPixMask'],
-                                                                                   startLoc=Config['Start_Location'],avgHWindow=Config['AvgHWindow_forTrace'],
-                                                                                   TraceHWidth=Config['HWidth_inXD'],trace_fit_deg=Config['ApertureTraceFuncDegree'],
-                                                                                   dispersion_Xaxis=Config['dispersion_Xaxis'],extrapolate_thresh=Config['extrapolate_thresh_forTrace'],
-                                                                                   extrapolate_order=Config['extrapolate_order_forTrace'], ShowPlot=Config['ShowPlot_Trace'],
-                                                                                   return_trace=True)
+            if Config['Mode'] == 'AUTO':
+                print("Automatic mode to create aperture trace")
+                ApertureLabel, ApertureCenters_Trace1 = CreateApertureLabelByXDFitting(Config['ContinuumFile'],BadPixMask=Config['BadPixMask'],
+                                                                                       startLoc=Config['Start_Location'],avgHWindow=Config['AvgHWindow_forTrace'],
+                                                                                       TraceHWidth=Config['HWidth_inXD'],trace_fit_deg=Config['ApertureTraceFuncDegree'],
+                                                                                       dispersion_Xaxis=Config['dispersion_Xaxis'],extrapolate_thresh=Config['extrapolate_thresh_forTrace'],
+                                                                                       extrapolate_order=Config['extrapolate_order_forTrace'], ShowPlot=Config['ShowPlot_Trace'],
+                                                                                       return_trace=True)
+            elif Config['Mode'] == 'MANUAL':
+                print("Manual mode to create aperture trace")
+                ApertureLabel, ApertureCenters_Trace1 = Manual_CreateApertureLabelByXDFitting(Config['ContinuumFile'],BadPixMask=Config['BadPixMask'],
+                                                                                       startLoc=Config['Start_Location'],avgHWindow=Config['AvgHWindow_forTrace'],
+                                                                                       TraceHWidth=Config['HWidth_inXD'],trace_fit_deg=Config['ApertureTraceFuncDegree'],
+                                                                                       dispersion_Xaxis=Config['dispersion_Xaxis'],extrapolate_thresh=Config['extrapolate_thresh_forTrace'],
+                                                                                       extrapolate_order=Config['extrapolate_order_forTrace'], ShowPlot=Config['ShowPlot_Trace'],
+                                                                                       return_trace=True)
+
             # Save the aperture label if a non existing filename was provided as input
             if isinstance(Config['ApertureLabel'],str):
                 np.save(Config['ApertureLabel'],ApertureLabel)

--- a/SpectrumExtractor/spectrum_extractor.py
+++ b/SpectrumExtractor/spectrum_extractor.py
@@ -1514,7 +1514,11 @@ def main(raw_args=None):
             ApertureLabel = np.load(Config['ApertureLabel'])
         else:
             # ApertureLabel = CreateApertureLabelByThresholding(Config['ContinuumFile'],BadPixMask=Config['BadPixMask'],bsize=51,offset=0,minarea=2000, ShowPlot=True,DirectlyEnterRelabel= True)
-            if Config['Mode'] == 'AUTO':
+            try:
+                trace_selection = Config['Mode']
+            except KeyError:
+                trace_selection = 'AUTO'
+            if trace_selection == 'AUTO':
                 print("Automatic mode to create aperture trace")
                 ApertureLabel, ApertureCenters_Trace1 = CreateApertureLabelByXDFitting(Config['ContinuumFile'],BadPixMask=Config['BadPixMask'],
                                                                                        startLoc=Config['Start_Location'],avgHWindow=Config['AvgHWindow_forTrace'],
@@ -1522,7 +1526,7 @@ def main(raw_args=None):
                                                                                        dispersion_Xaxis=Config['dispersion_Xaxis'],extrapolate_thresh=Config['extrapolate_thresh_forTrace'],
                                                                                        extrapolate_order=Config['extrapolate_order_forTrace'], ShowPlot=Config['ShowPlot_Trace'],
                                                                                        return_trace=True)
-            elif Config['Mode'] == 'MANUAL':
+            elif trace_selection == 'MANUAL':
                 print("Manual mode to create aperture trace")
                 ApertureLabel, ApertureCenters_Trace1 = Manual_CreateApertureLabelByXDFitting(Config['ContinuumFile'],BadPixMask=Config['BadPixMask'],
                                                                                        startLoc=Config['Start_Location'],avgHWindow=Config['AvgHWindow_forTrace'],

--- a/SpectrumExtractor/spectrum_extractor.py
+++ b/SpectrumExtractor/spectrum_extractor.py
@@ -511,7 +511,7 @@ def Get_SlitShearFunction(ApertureCenters):
     return ApertureSlitShearFuncDic
 
 def CalculateShiftInXD(SpectrumImage, RefImage=None, XDshiftmodel='p0',Coeffmodel='p0', DWindowToUse=None, StripWidth=50,
-                       Apodize=True, bkg_medianfilt=False,dispersion_Xaxis=True,ShowPlot=False):
+                       Apodize=True, bkg_medianfilt=False,dispersion_Xaxis=True,ShowPlot=False, PlotPrifix=None):
     """ Calculates the avg shift in XD to match SpectrumImage to RefImage
     Returns Avg_XD_shift coeffiencts in the domain the XD pixels are scaled to -1 to 1
     if Coeffmodel is pi, where i >0 then an i degree polynomial fit is made to the coefficents of the XDshift model acorss the dispersion pixels"""
@@ -574,10 +574,18 @@ def CalculateShiftInXD(SpectrumImage, RefImage=None, XDshiftmodel='p0',Coeffmode
             logging.debug('XD offset fit {0}:{1}'.format(i,fitted_driftp))
             XDShiftCoeffDict[centerx] = fitted_driftp
             if ShowPlot:
-                # plt.figure()
+
                 plt.plot(newRefFlux[:,0],newRefFlux[:,1]*fitted_driftp[0],color='k',alpha=0.3, label="Reference aperture position")
                 plt.plot(shifted_pixels,SumApFluxSpectrum,color='g',alpha=0.3, label="Observed aperture position")
-                # plt.show(block=False)
+                if PlotPrifix is not None:
+                    fig2, ax2 = plt.subplots(figsize=(8,8))
+                    ax2.plot(newRefFlux[:,0],newRefFlux[:,1]*fitted_driftp[0],color='k',alpha=0.6, label="Reference aperture position")
+                    ax2.plot(shifted_pixels,SumApFluxSpectrum,color='g',alpha=0.6, label="Observed aperture position")
+                    plt.xlabel('XD pixels')
+                    plt.ylabel('Apodized counts')
+                    ax2.legend()
+                    fig2.savefig(PlotPrifix + "_{}.png".format(i))
+                    plt.close(fig2)
 
     if int(Coeffmodel[1:]) == 0:
         Avg_XD_shift = biweight_location(np.array(list(XDShiftCoeffDict.values())),axis=0)[1:] #remove the flux scale coeff
@@ -1295,7 +1303,17 @@ def main(raw_args=None):
         logging.warning('WARNING: Output file {0} already exist'.format(OutputFile))
         logging.warning('Skipping this image extraction..')
         sys.exit(1)
-
+    if Config['ShowPlot_Trace']:
+        parent_dir = os.path.dirname(OutputFile)
+        plot_dir = os.path.join(parent_dir, "ApertureTrace_Plots")
+        if not os.path.exists(plot_dir):
+            os.mkdir(plot_dir)
+        plot_fname = os.path.splitext(os.path.basename(OutputFile))[0]
+        plot_fname = os.path.join(plot_dir, plot_fname)
+    else:
+        plot_fname = None
+        
+        
     ################################################################################
     # Starting Extraction process
     ################################################################################
@@ -1411,7 +1429,7 @@ def main(raw_args=None):
                                                          XDshiftmodel=XDshiftmodel,Coeffmodel=DCoeffmodel,DWindowToUse=Config['ReFitApertureInXD_DWindow'],
                                                          StripWidth=4*Config['AvgHWindow_forTrace'],Apodize=True,
                                                          bkg_medianfilt=Config['ReFitApertureInXD_BkgMedianFilt'],
-                                                         dispersion_Xaxis=Config['dispersion_Xaxis'],ShowPlot=Config['ShowPlot_Trace'])
+                                                         dispersion_Xaxis=Config['dispersion_Xaxis'],ShowPlot=Config['ShowPlot_Trace'],PlotPrifix=plot_fname)
             logging.info('Fitted shift in XD position :{0} in -1to1 domain of {1}'.format(tuple(Avg_XD_shift),tuple(PixDomain)))
         # Apply the XD shift to the aperture centers
         ApertureCenters = ApplyXDshiftToApertureCenters(ApertureCenters,Avg_XD_shift,PixDomain)
@@ -1427,7 +1445,7 @@ def main(raw_args=None):
     if Config['ShowPlot_Trace']:
         norm = ImageNormalize(SpectrumImage, interval=PercentileInterval(95.),
                               stretch=SqrtStretch())
-        fig = plt.figure()
+        fig = plt.figure(figsize=(12,12))
         ax = fig.add_subplot(1, 1, 1)
         if Config['dispersion_Xaxis']:
             im = ax.imshow(SpectrumImage, origin='lower', norm=norm, cmap='gray')
@@ -1448,6 +1466,8 @@ def main(raw_args=None):
                     ax.plot(x,ApertureTraceFuncDic[order](x)+bkgw_offset,ls='--',color='deeppink')
         ax.set_title('Fitted Aperture: Star in Cyan & Background in Pink')
         ax.set_ylim(ylim)
+        plt.tight_layout()
+        plt.savefig(plot_fname + "_Frame.png")
         plt.show()
     ################################################################################
     # Spectral Extraction starts here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools<60", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
If the user is not satisfied on trace fitting, they should be able to manually select the traces. So, a new feature is added to the package to select the points on the trace manually. Insted of automatically fitting the trace by WavelengthCalibrationTool, the trace will open in imshow. Then the user can select the points on each aperture. User can select the points on one apertue at a time.